### PR TITLE
fix: add /v2 suffix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/aereal/go-aws-arn-utils
+module github.com/aereal/go-aws-arn-utils/v2
 
 go 1.15
 


### PR DESCRIPTION
refs. https://blog.golang.org/v2-go-modules